### PR TITLE
OPUSVIER-4333: BibTeX import CLI command adjustments

### DIFF
--- a/src/Import/Config/BibtexMapping.php
+++ b/src/Import/Config/BibtexMapping.php
@@ -136,7 +136,7 @@ class BibtexMapping
      * wird vor der Ausführung aller anderen Regeln ausgeführt. Existiert bereits eine Regel mit dem
      * übergebenen Namen, so wird diese Regel vor dem Hinzufügen der übergebenen Regel entfernt.
      *
-     * @param string $name Name der Regel
+     * @param string             $name Name der Regel
      * @param RuleInterface|null $rule die hinzuzufügende Regel (wenn null, dann wird die Regel aus dem Namen abgeleitet)
      * @return $this
      */
@@ -156,7 +156,7 @@ class BibtexMapping
      * wird erst nach der Ausführung aller anderen Regeln ausgeführt. Existiert bereits eine Regel mit dem
      * übergebenen Namen, so wird diese Regel vor dem Hinzufügen der übergebenen Regel entfernt.
      *
-     * @param string $name Name der Regel
+     * @param string             $name Name der Regel
      * @param RuleInterface|null $rule die hinzuzufügende Regel (wenn null, dann wird die Regel aus dem Namen abgeleitet)
      * @return $this
      */
@@ -175,8 +175,8 @@ class BibtexMapping
      * Überschreibt die unter dem Namen registrierte Regel oder fügt die Regel am Ende der Regelliste hinzu, falls
      * unter dem übergebenen Namen noch keine Regel existiert.
      *
-     * @param string $name Name der Regel
-     * @param RuleInterface $rule die zu ersetzende (oder hinzuzufügende) Regel
+     * @param string             $name Name der Regel
+     * @param null|RuleInterface $rule die zu ersetzende (oder hinzuzufügende) Regel
      * @return $this
      */
     public function updateRule($name, $rule = null)

--- a/src/Import/Config/BibtexService.php
+++ b/src/Import/Config/BibtexService.php
@@ -61,7 +61,7 @@ class BibtexService
      */
     const INI_FILE = 'import.ini';
 
-    /** @var BibtexService|null interne Instanz der Klasse (für Durchsetzung des Singleton-Patterns) */
+    /** @var self|null interne Instanz der Klasse (für Durchsetzung des Singleton-Patterns) */
     private static $instance;
 
     /** @var string Name der auszuwertenden INI-Konfigurationsdatei. */
@@ -80,9 +80,9 @@ class BibtexService
     /**
      * Liefert eine Instanz der Klasse zurück; erzeugt eine Instanz, wenn bislang noch keine Instanz erzeugt wurde.
      *
-     * @param null $iniFileName Name der INI-Datei, die zur Konfiguration genutzt werden soll (wenn nicht gesetzt, so
-     *                          wird die Standardkonfigurationsdate verwendet)
-     * @return BibtexService
+     * @param null|string $iniFileName Name der INI-Datei, die zur Konfiguration genutzt werden soll
+     *                                 (wenn nicht gesetzt, so wird die Standardkonfigurationsdate verwendet)
+     * @return self
      * @throws BibtexConfigException
      */
     public static function getInstance($iniFileName = null)

--- a/src/Import/Config/DocumentTypeMapping.php
+++ b/src/Import/Config/DocumentTypeMapping.php
@@ -123,7 +123,7 @@ class DocumentTypeMapping
      * zurückgegeben. Ist kein Default-Typ definiert, so wird null zurückgegeben.
      *
      * @param string $bibtexType Name des BibTeX-Typs
-     * @param bool $useDefaultAsFallback False deaktiviert Fallback auf Defaulttyp.
+     * @param bool   $useDefaultAsFallback False deaktiviert Fallback auf Defaulttyp.
      * @return string|null Name des zugehörigen OPUS-Dokumenttyps (oder null, wenn kein Mapping möglich)
      *
      * TODO macht $useDefaultAsFallback Sinn? Wie/wo wird es verwendet?

--- a/src/Import/Console/Helper/BibtexImportHelper.php
+++ b/src/Import/Console/Helper/BibtexImportHelper.php
@@ -154,6 +154,12 @@ class BibtexImportHelper
         }
         $processor = new Processor($fieldMapping);
 
+        $importId   = uniqid('', true);
+        $importDate = gmdate('c');
+
+        $bibtexImportResult->addMessage('Unique ID of import run: ' . $importId);
+        $bibtexImportResult->addMessage('Date of import: ' . $importDate);
+
         // BibTeX-Records werden einzeln importiert: im Fehlerfall wird zum zum nächsten BibTeX-Record gesprungen
         foreach ($bibtexRecords as $bibtexRecord) {
             $bibtexImportResult->increaseNumDocsProcessed();
@@ -177,7 +183,7 @@ class BibtexImportHelper
                         $doc->addCollection($collection);
                     }
 
-                    $this->addImportEnrichments($doc);
+                    $this->addImportEnrichments($doc, $importId, $importDate);
 
                     try {
                         $doc = Document::get($doc->store());
@@ -273,13 +279,15 @@ class BibtexImportHelper
      * existieren.
      *
      * @param Document $document das importierte OPUS-Dokument
+     * @param string   $importId eindeutige ID des Import-Durchlaufs
+     * @param string   $importDate Datum des Imports
      */
-    private function addImportEnrichments($document)
+    private function addImportEnrichments($document, $importId, $importDate)
     {
-        $this->createEnrichment($document, 'opus.import.date', gmdate('c'));
+        $this->createEnrichment($document, 'opus.import.date', $importDate);
         $this->createEnrichment($document, 'opus.import.file', $this->fileName);
         $this->createEnrichment($document, 'opus.import.format', 'bibtex');
-        $this->createEnrichment($document, 'opus.import.id', uniqid('', true));
+        $this->createEnrichment($document, 'opus.import.id', $importId);
     }
 
     /**

--- a/src/Import/Console/Helper/BibtexImportResult.php
+++ b/src/Import/Console/Helper/BibtexImportResult.php
@@ -38,6 +38,8 @@ namespace Opus\Bibtex\Import\Console\Helper;
 use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\Output;
 
+use const PHP_EOL;
+
 class BibtexImportResult
 {
     /**
@@ -58,8 +60,8 @@ class BibtexImportResult
     /** @var Output Ausgabepuffer für Meldungen während des BibTeX-Imports */
     private $output;
 
-    /** @var array */
-    private $messages = [];
+    /** @var string speichert die Ausgaben während der Verarbeitung */
+    private $messages = '';
 
     /**
      * Maximale Anzahl der Status-Indikatorzeichen in einer Bildschirmzeile
@@ -80,7 +82,7 @@ class BibtexImportResult
     }
 
     /**
-     * @return int
+     * @return int Anzahl der verarbeiteten Dokumente
      */
     public function getNumDocsProcessed()
     {
@@ -93,7 +95,7 @@ class BibtexImportResult
     }
 
     /**
-     * @return int
+     * @return int Anzahl der importierten Dokumente
      */
     public function getNumDocsImported()
     {
@@ -101,7 +103,23 @@ class BibtexImportResult
     }
 
     /**
-     * @return array
+     * @return int Anzahl der aufgrund von Fehlern nicht importierten BibTeX-Records
+     */
+    public function getNumErrors()
+    {
+        return $this->numErrors;
+    }
+
+    /**
+     * @return int Anzahl der aufgrund von Hashwert-Übereinstimmung nicht importierten BibTeX-Records
+     */
+    public function getNumSkipped()
+    {
+        return $this->numSkipped;
+    }
+
+    /**
+     * @return string
      */
     public function getMessages()
     {
@@ -114,7 +132,7 @@ class BibtexImportResult
     public function addMessage($message)
     {
         $this->output->writeln($message);
-        $this->messages[] = $message;
+        $this->messages .= $message . PHP_EOL;
     }
 
     /**
@@ -173,8 +191,10 @@ class BibtexImportResult
     {
         if (! $verbose) {
             $this->output->write($statusStr);
+            $this->messages .= $statusStr;
             if ($this->numDocsProcessed % self::STATUS_LINE_WIDTH === 0) {
                 $this->output->writeln(''); // neue Zeile beginnen
+                $this->messages .= PHP_EOL;
             }
         }
     }

--- a/src/Import/Parser.php
+++ b/src/Import/Parser.php
@@ -94,17 +94,17 @@ class Parser
             }
         } catch (ParserException $e) {
             // Fehler beim Parsen des BibTeX
-            throw new \Opus\Bibtex\Import\ParserException();
+            throw new \Opus\Bibtex\Import\ParserException($e->getMessage());
         } catch (ErrorException $e) {
             // Fehler beim Einlesen der übergebenen Datei
-            throw new \Opus\Bibtex\Import\ParserException();
+            throw new \Opus\Bibtex\Import\ParserException($e->getMessage());
         }
 
         try {
             $result = $listener->export();
         } catch (ProcessorException $e) {
             // im Feldinhalt eines Felds befindet sich ein unerwartetes Zeichen
-            throw new \Opus\Bibtex\Import\ParserException();
+            throw new \Opus\Bibtex\Import\ParserException($e->getMessage());
         }
         return $result;
     }

--- a/src/Import/Parser.php
+++ b/src/Import/Parser.php
@@ -36,7 +36,6 @@
 namespace Opus\Bibtex\Import;
 
 use ErrorException;
-use RenanBr\BibTexParser\Exception\ParserException;
 use RenanBr\BibTexParser\Exception\ProcessorException;
 use RenanBr\BibTexParser\Listener;
 use RenanBr\BibTexParser\Processor\LatexToUnicodeProcessor;
@@ -91,7 +90,7 @@ class Parser
             } else {
                 $parser->parseString($this->bibtex);
             }
-        } catch (ParserException $e) {
+        } catch (\RenanBr\BibTexParser\Exception\ParserException $e) {
             // Fehler beim Parsen des BibTeX
             throw new ParserException($e->getMessage());
         } catch (ErrorException $e) {

--- a/src/Import/Parser.php
+++ b/src/Import/Parser.php
@@ -73,9 +73,8 @@ class Parser
      * von BibTeX-Feldnamen auf die zugehörigen Werte zurück.
      *
      * @return array
-     * @throws ParserException Wird geworfen, wenn beim Parsing Fehler aufgetreten sind, z.B. weil
-     *                                             die BibTeX-Datei nicht lesbar ist oder im BibTeX-Record Formatfehler
-     *                                             existieren.
+     * @throws ParserException Wird geworfen, wenn beim Parsing Fehler aufgetreten sind, z.B. weil die BibTeX-Datei
+     *                         nicht lesbar ist oder im BibTeX-Record Formatfehler existieren.
      */
     public function parse()
     {

--- a/src/Import/Parser.php
+++ b/src/Import/Parser.php
@@ -73,7 +73,7 @@ class Parser
      * von BibTeX-Feldnamen auf die zugehörigen Werte zurück.
      *
      * @return array
-     * @throws \Opus\Bibtex\Import\ParserException Wird geworfen, wenn beim Parsing Fehler aufgetreten sind, z.B. weil
+     * @throws ParserException Wird geworfen, wenn beim Parsing Fehler aufgetreten sind, z.B. weil
      *                                             die BibTeX-Datei nicht lesbar ist oder im BibTeX-Record Formatfehler
      *                                             existieren.
      */
@@ -94,17 +94,17 @@ class Parser
             }
         } catch (ParserException $e) {
             // Fehler beim Parsen des BibTeX
-            throw new \Opus\Bibtex\Import\ParserException($e->getMessage());
+            throw new ParserException($e->getMessage());
         } catch (ErrorException $e) {
             // Fehler beim Einlesen der übergebenen Datei
-            throw new \Opus\Bibtex\Import\ParserException($e->getMessage());
+            throw new ParserException($e->getMessage());
         }
 
         try {
             $result = $listener->export();
         } catch (ProcessorException $e) {
             // im Feldinhalt eines Felds befindet sich ein unerwartetes Zeichen
-            throw new \Opus\Bibtex\Import\ParserException($e->getMessage());
+            throw new ParserException($e->getMessage());
         }
         return $result;
     }

--- a/src/Import/Parser.php
+++ b/src/Import/Parser.php
@@ -36,8 +36,10 @@
 namespace Opus\Bibtex\Import;
 
 use ErrorException;
+use RenanBr\BibTexParser\Exception\ParserException as BibTexParserException;
 use RenanBr\BibTexParser\Exception\ProcessorException;
 use RenanBr\BibTexParser\Listener;
+use RenanBr\BibTexParser\Parser as BibTexParser;
 use RenanBr\BibTexParser\Processor\LatexToUnicodeProcessor;
 
 use function array_keys;
@@ -77,7 +79,7 @@ class Parser
      */
     public function parse()
     {
-        $parser = new \RenanBr\BibTexParser\Parser();
+        $parser = new BibTexParser();
 
         $listener = new Listener();
         $listener->addProcessor(new LatexToUnicodeProcessor()); // behandelt alle Felder (weil leere Blacklist)
@@ -90,7 +92,7 @@ class Parser
             } else {
                 $parser->parseString($this->bibtex);
             }
-        } catch (\RenanBr\BibTexParser\Exception\ParserException $e) {
+        } catch (BibTexParserException $e) {
             // Fehler beim Parsen des BibTeX
             throw new ParserException($e->getMessage());
         } catch (ErrorException $e) {

--- a/src/Import/Rules/AbstractComplexRule.php
+++ b/src/Import/Rules/AbstractComplexRule.php
@@ -80,6 +80,9 @@ abstract class AbstractComplexRule implements RuleInterface
                     unset($this->fieldsEvaluated[$fieldName]);
                 }
             }
+        } else {
+            // es können alle Felder des BibTeX-Records ausgewertet werden
+            $fieldValues = $bibtexRecord;
         }
         // FIXME wir können nicht wirklich sicherstellen, dass beim Aufruf von setFields tatsächlich auf die in
         //       $fieldValues angegebenen Werte des BibTeX-Records zugegriffen wird
@@ -98,7 +101,7 @@ abstract class AbstractComplexRule implements RuleInterface
 
     /**
      * Diese Methode muss von Klassen, die AbstractComplexRule ableiten, überschrieben / definiert werden.
-     * Die Methode bestimmt erlaubt das Setzen der OPUS-Metadatenfelder auf Basis der übergebenen Werte von
+     * Die Methode erlaubt das Setzen der OPUS-Metadatenfelder auf Basis der übergebenen Werte von
      * BibTeX-Feldern.
      *
      * @param array $fieldValues Werte von BibTeX-Feldern

--- a/src/Import/Rules/RuleInterface.php
+++ b/src/Import/Rules/RuleInterface.php
@@ -41,7 +41,7 @@ interface RuleInterface
      * @param array $bibtexRecord BibTeX-Record (als Array von BibTeX-Feldern), der importiert werden soll
      * @param array $documentMetadata OPUS-Metadatensatz (als Array von Metadatenfeldern), der unter Nutzung der
      *                                Funktion fromArray in ein OPUS4-Dokument umgewandelt werden soll
-     * @return boolean Aussage über den Erfolg der Anwendung der Regel (true gdw. erfolgreiche Anwendung)
+     * @return bool Aussage über den Erfolg der Anwendung der Regel (true gdw. erfolgreiche Anwendung)
      */
     public function apply($bibtexRecord, &$documentMetadata);
 

--- a/src/Import/Rules/SimpleRule.php
+++ b/src/Import/Rules/SimpleRule.php
@@ -53,10 +53,10 @@ class SimpleRule implements RuleInterface
     protected $opusField;
 
     /**
-     * @param string $bibtexField Name des auszuwertenden BibTeX-Felds
-     * @param string $opusField Name des zu befüllenden OPUS4-Metadatenfelds
+     * @param null|string $bibtexField Name des auszuwertenden BibTeX-Felds
+     * @param null|string $opusField Name des zu befüllenden OPUS4-Metadatenfelds
      */
-    public function __construct($bibtexField = null, string $opusField = null)
+    public function __construct($bibtexField = null, $opusField = null)
     {
         $this->setBibtexField($bibtexField);
         $this->setOpusField($opusField);

--- a/src/Import/Rules/Umlauts.php
+++ b/src/Import/Rules/Umlauts.php
@@ -71,7 +71,7 @@ class Umlauts extends AbstractComplexRule
      * Wandelt jeden speziell angegebenen Umlaut im übergebenen Feldwert in das zugehörige Unicode-Zeichen um.
      *
      * @param string $value Feldwert, der ggf. umzuwandelnde Umlaute enthält
-     * @return string|boolean liefert den umgewandelten Wert oder false, falls keine Umwandlung von Zeichen erfolgt ist
+     * @return string|bool liefert den umgewandelten Wert oder false, falls keine Umwandlung von Zeichen erfolgt ist
      */
     protected function convertUmlauts($value)
     {
@@ -119,7 +119,7 @@ class Umlauts extends AbstractComplexRule
      *
      * @param string $fieldName Feldname
      * @param string $fieldValue Feldwert
-     * @param array $documentMetadata OPUS-Metadatensatz
+     * @param array  $documentMetadata OPUS-Metadatensatz
      */
     private function setSimpleField($fieldName, $fieldValue, &$documentMetadata)
     {
@@ -137,8 +137,8 @@ class Umlauts extends AbstractComplexRule
      * werden soll.
      *
      * @param string $fieldName Feldname
-     * @param array $fieldValue Feldwert
-     * @param array $documentMetadata OPUS-Metadatensatz
+     * @param array  $fieldValue Feldwert
+     * @param array  $documentMetadata OPUS-Metadatensatz
      */
     private function setArrayField($fieldName, $fieldValue, &$documentMetadata)
     {
@@ -158,7 +158,7 @@ class Umlauts extends AbstractComplexRule
     /**
      * Prüft, ob das Metadatenfeld bei der Umlautbehandlung berücksichtigt werden soll.
      *
-     * @param string $fieldName Feldbezeichnung
+     * @param string       $fieldName Feldbezeichnung
      * @param string|array $fieldValue Feldwert
      * @return bool Liefert true, gdw. das Feld bei der Umlautbehandlung nicht berücksichtigt werden soll.
      */

--- a/src/Import/import.ini
+++ b/src/Import/import.ini
@@ -1,6 +1,7 @@
 ; Registrierung der Namen von Konfigurationsdateien, in denen die Abbildung der einzelnen BibTeX-Felder auf
 ; OPUS-Metadatenfelder definiert wird
 ; ein hier registriertes Field-Mapping kann in der CLI bzw. Administration über seinen Namen referenziert werden
+; die angegebenen JSON-Dateien müssen sich im Verzeichnis der INI-Konfigurationsdatei befinden, um aufgelöst zu werden
 fieldMappings[] = default-mapping.json
 
 ; Standard-OPUS-Dokumenttyp, sofern für den im BibTeX-Record vorliegenden BibTeX-Typ kein Typ-Mapping auf einen

--- a/test/Import/ParserTest.php
+++ b/test/Import/ParserTest.php
@@ -54,6 +54,7 @@ use function preg_split;
 use function strpos;
 use function strtolower;
 use function trim;
+use function json_encode;
 
 use const DIRECTORY_SEPARATOR;
 use const PREG_SPLIT_DELIM_CAPTURE;
@@ -998,7 +999,7 @@ class ParserTest extends TestCase
      */
     public function testProcessor()
     {
-        $bibtex       = "@misc{Nobody06,\n       author = \"Nobody, Jr\",\n       title = \"My Article\",\n       year = \"2006\"}";
+        $bibtex = "@misc{Nobody06,\n       author = \"Nobody, Jr\",\n       title = \"My Article\",\n       year = \"2006\"}";
 
         $processor   = new Processor();
         $bibtexArray = [

--- a/test/Import/ParserTest.php
+++ b/test/Import/ParserTest.php
@@ -216,9 +216,14 @@ class ParserTest extends TestCase
             $bibtexRecord,
             $enrichments[0]
         );
+
+        $resultSorted = $result[0];
+        ksort($resultSorted);
+        unset($resultSorted['_type']);
+        unset($resultSorted['_original']);
         $this->assertEnrichment(
             SourceDataHash::SOURCE_DATA_HASH_KEY,
-            SourceDataHash::HASH_FUNCTION . ':' . (SourceDataHash::HASH_FUNCTION)($bibtexRecord),
+            SourceDataHash::HASH_FUNCTION . ':' . (SourceDataHash::HASH_FUNCTION)(json_encode($resultSorted)),
             $enrichments[1]
         );
     }
@@ -994,8 +999,6 @@ class ParserTest extends TestCase
     public function testProcessor()
     {
         $bibtex       = "@misc{Nobody06,\n       author = \"Nobody, Jr\",\n       title = \"My Article\",\n       year = \"2006\"}";
-        $hashFunction = SourceDataHash::HASH_FUNCTION;
-        $bibtexHash   = $hashFunction($bibtex);
 
         $processor   = new Processor();
         $bibtexArray = [
@@ -1006,6 +1009,11 @@ class ParserTest extends TestCase
             'year'         => '2006',
             '_original'    => $bibtex,
         ];
+
+        $bibtexArraySorted = $bibtexArray;
+        unset($bibtexArraySorted['_original']);
+        ksort($bibtexArraySorted);
+        $bibtexHash = (SourceDataHash::HASH_FUNCTION)(json_encode($bibtexArraySorted));
 
         $opus = [
             'BelongsToBibliography' => false,
@@ -1033,7 +1041,7 @@ class ParserTest extends TestCase
                 ],
                 [
                     'KeyName' => SourceDataHash::SOURCE_DATA_HASH_KEY,
-                    'Value'   => $hashFunction . ':' . $bibtexHash,
+                    'Value'   => SourceDataHash::HASH_FUNCTION . ':' . $bibtexHash,
                 ],
             ],
         ];

--- a/test/Import/ParserTest.php
+++ b/test/Import/ParserTest.php
@@ -226,7 +226,7 @@ class ParserTest extends TestCase
     /**
      * @param string $keyName Expected key
      * @param string $value Expected value
-     * @param array $enrichment Parsed BibTeX data
+     * @param array  $enrichment Parsed BibTeX data
      */
     private function assertEnrichment($keyName, $value, $enrichment)
     {
@@ -238,7 +238,7 @@ class ParserTest extends TestCase
      * @param string $role Expected role of person, like "author"
      * @param string $firstName Expected first name
      * @param string $lastName Expected last name
-     * @param array $person Parsed BibTeX data
+     * @param array  $person Parsed BibTeX data
      */
     private function assertPerson($role, $firstName, $lastName, $person)
     {
@@ -254,7 +254,7 @@ class ParserTest extends TestCase
     /**
      * @param string $titleType Expected type of title
      * @param string $titleValue Expected value of title
-     * @param array $title Parsed BibTeX data
+     * @param array  $title Parsed BibTeX data
      */
     private function assertTitle($titleType, $titleValue, $title)
     {
@@ -265,7 +265,7 @@ class ParserTest extends TestCase
 
     /**
      * @param string $value Expected value
-     * @param array $subject Parsed BibTeX data
+     * @param array  $subject Parsed BibTeX data
      */
     private function assertSubject($value, $subject)
     {
@@ -276,7 +276,7 @@ class ParserTest extends TestCase
 
     /**
      * @param string $message Expected message
-     * @param array $note Parsed BibTeX data
+     * @param array  $note Parsed BibTeX data
      */
     private function assertNote($message, $note)
     {

--- a/test/Import/ParserTest.php
+++ b/test/Import/ParserTest.php
@@ -49,12 +49,12 @@ use function array_keys;
 use function array_map;
 use function file_get_contents;
 use function in_array;
+use function json_encode;
 use function ksort;
 use function preg_split;
 use function strpos;
 use function strtolower;
 use function trim;
-use function json_encode;
 
 use const DIRECTORY_SEPARATOR;
 use const PREG_SPLIT_DELIM_CAPTURE;

--- a/test/Import/Rules/BelongsToBibliographyTest.php
+++ b/test/Import/Rules/BelongsToBibliographyTest.php
@@ -58,7 +58,7 @@ class BelongsToBibliographyTest extends TestCase
 
     /**
      * @param mixed $arg Test config value
-     * @param bool $res Expected result
+     * @param bool  $res Expected result
      * @dataProvider dataProvider
      */
     public function testProcess($arg, $res)

--- a/test/Import/Rules/DocumentTypeTest.php
+++ b/test/Import/Rules/DocumentTypeTest.php
@@ -58,7 +58,6 @@ class DocumentTypeTest extends TestCase
      *
      * @param string $arg Value to check given by the data provider
      * @param string $res expected mapping-result
-     * @return void
      * @dataProvider dataProvider
      */
     public function testProcessMapping($arg, $res)
@@ -164,7 +163,7 @@ class DocumentTypeTest extends TestCase
 
     /**
      * @param string $docType Document type
-     * @param array $bibtexBlock BibTeX data
+     * @param array  $bibtexBlock BibTeX data
      * @param string $expectedType Expected document type
      */
     private function assertTypeField($docType, $bibtexBlock, $expectedType)

--- a/test/Import/Rules/ParentTitleTest.php
+++ b/test/Import/Rules/ParentTitleTest.php
@@ -52,7 +52,7 @@ class ParentTitleTest extends TestCase
     /**
      * Test Mapping of Publication-types.
      *
-     * @param mixed $arg Value to check given by the data provider
+     * @param mixed  $arg Value to check given by the data provider
      * @param string $res expected mapping-result
      * @dataProvider dataProvider
      */

--- a/test/Import/Rules/SourceDataHashTest.php
+++ b/test/Import/Rules/SourceDataHashTest.php
@@ -41,6 +41,7 @@ use Opus\Bibtex\Import\Rules\SourceDataHash;
 use PHPUnit\Framework\TestCase;
 
 use function json_encode;
+use function ksort;
 
 class SourceDataHashTest extends TestCase
 {

--- a/test/Import/Rules/TitleTest.php
+++ b/test/Import/Rules/TitleTest.php
@@ -51,7 +51,7 @@ class TitleTest extends TestCase
     /**
      * Test title-rule.
      *
-     * @param mixed $arg Value to check given by the data provider
+     * @param mixed  $arg Value to check given by the data provider
      * @param string $res expected mapping-result
      * @dataProvider dataProvider
      */


### PR DESCRIPTION
Einige (letzte) kleinere Nachbesserungen im Import-Kommando:

- Verarbeitung der Logausgabe, die während des BibTeX-Imports erzeugt wird
- Exception Message Handling
- Dokumentation
- Dry Mode Anwendung
- Zugriffsprüfung auf BibTeX-Datei
- Coding Style Verletzungen
- robustere Behandlung von Duplikaten (Kanonisierung)