### PR TITLE
OPUSVIER-4557: robust handling of empty BibTeX fields

### DIFF
--- a/src/Import/Parser.php
+++ b/src/Import/Parser.php
@@ -45,6 +45,7 @@ use RenanBr\BibTexParser\Processor\LatexToUnicodeProcessor;
 use function array_keys;
 use function is_file;
 use function substr;
+use function trim;
 
 /**
  * Liest eine übergebene BibTeX-Datei bzw. eine Zeichenkette, die ein oder mehrere BibTeX-Records enthält ein und
@@ -106,6 +107,8 @@ class Parser
             // im Feldinhalt eines Felds befindet sich ein unerwartetes Zeichen
             throw new ParserException($e->getMessage());
         }
+
+        $this->removeEmptyFields($result);
         return $result;
     }
 
@@ -127,5 +130,22 @@ class Parser
             $result[] = $fieldName;
         }
         return $result;
+    }
+
+    /**
+     * Entfernt in den übergenenen BibTeX-Records alle BibTeX-Felder, die einen leeren Feldinhalt besitzen.
+     *
+     * @param array $bibtexRecords Array von BibTeX-Records
+     */
+    private function removeEmptyFields(&$bibtexRecords)
+    {
+        foreach ($bibtexRecords as $index => $bibtexRecord) {
+            foreach ($bibtexRecord as $key => $value) {
+                if (trim($value) === '') {
+                    unset($bibtexRecord[$key]);
+                }
+            }
+            $bibtexRecords[$index] = $bibtexRecord;
+        }
     }
 }

--- a/test/Import/ParserTest.php
+++ b/test/Import/ParserTest.php
@@ -47,6 +47,7 @@ use PHPUnit\Framework\TestCase;
 use function array_diff;
 use function array_keys;
 use function array_map;
+use function count;
 use function file_get_contents;
 use function in_array;
 use function json_encode;
@@ -55,7 +56,6 @@ use function preg_split;
 use function strpos;
 use function strtolower;
 use function trim;
-use function count;
 
 use const DIRECTORY_SEPARATOR;
 use const PREG_SPLIT_DELIM_CAPTURE;

--- a/test/Import/ParserTest.php
+++ b/test/Import/ParserTest.php
@@ -1080,6 +1080,24 @@ class ParserTest extends TestCase
     }
 
     /**
+     * Regression Test of OPUSVIER-4557: Filter BibTeX fields with empty field value.
+     */
+    public function testProcessEmptyFields()
+    {
+        $testfile = $this->getPath('empty-fields.bib');
+
+        $parser = new Parser($testfile);
+        $result = $parser->parse();
+        $this->assertCount(1, $result);
+        $bibTexRecord = $result[0];
+        $this->assertEquals('article', $bibTexRecord['type']);
+        $this->assertEquals('article', $bibTexRecord['_type']);
+        $this->assertEquals('Foo2021', $bibTexRecord['citation-key']);
+        $this->assertArrayHasKey('_original', $bibTexRecord);
+        $this->assertEquals(4, count($bibTexRecord));
+    }
+
+    /**
      * @param string $fileName Name of file
      * @return string Path to file
      */

--- a/test/Import/ParserTest.php
+++ b/test/Import/ParserTest.php
@@ -55,6 +55,7 @@ use function preg_split;
 use function strpos;
 use function strtolower;
 use function trim;
+use function count;
 
 use const DIRECTORY_SEPARATOR;
 use const PREG_SPLIT_DELIM_CAPTURE;

--- a/test/Import/_files/empty-fields.bib
+++ b/test/Import/_files/empty-fields.bib
@@ -1,0 +1,13 @@
+@article{Foo2021,
+    Author       = " ",
+    Title        = "    ",
+    Editor       = "
+                    ",
+    Booktitle    = "",
+    Year         = "",
+    Publisher    = "",
+    Pages        = "",
+    Isbn         = "",
+    Doi          = "",
+    Language     = ""
+}


### PR DESCRIPTION
Ignore BibTeX fields with empty field values silently. Do not consider those fields when creating OPUS metadata fields.